### PR TITLE
feat: cache databases in memory

### DIFF
--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -11,6 +11,7 @@ import (
 	commonMiddleware "github.com/hibare/GoCommon/pkg/http/middleware"
 	"github.com/hibare/GoGeoIP/internal/config"
 	"github.com/hibare/GoGeoIP/internal/constants"
+	"github.com/hibare/GoGeoIP/internal/maxmind"
 	"github.com/hibare/GoGeoIP/internal/testhelper"
 	"github.com/stretchr/testify/assert"
 )
@@ -158,6 +159,9 @@ func TestGeoIP200(t *testing.T) {
 	err := testhelper.LoadTestDB()
 	assert.NoError(t, err)
 
+	err = maxmind.LoadAllDB()
+	assert.NoError(t, err)
+
 	t.Cleanup(func() {
 		os.RemoveAll(constants.AssetDir)
 	})
@@ -193,6 +197,9 @@ func TestGeoIP200(t *testing.T) {
 
 func TestMyIP200(t *testing.T) {
 	err := testhelper.LoadTestDB()
+	assert.NoError(t, err)
+
+	err = maxmind.LoadAllDB()
 	assert.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/internal/maxmind/database.go
+++ b/internal/maxmind/database.go
@@ -1,0 +1,68 @@
+package maxmind
+
+import (
+	"sync"
+
+	"github.com/hibare/GoGeoIP/internal/constants"
+	"github.com/oschwald/geoip2-golang"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	dbCountryReader *geoip2.Reader
+	dbCityReader    *geoip2.Reader
+	dbAsnReader     *geoip2.Reader
+	dbLock					sync.Mutex
+)
+
+func LoadAllDB() error {
+	var err error
+
+	dbCountryReader, err = loadDB(constants.DBTypeCountry)
+	if err != nil {
+		return err
+	}
+
+	dbCityReader, err = loadDB(constants.DBTypeCity)
+	if err != nil {
+		return err
+	}
+
+	dbAsnReader, err = loadDB(constants.DBTypeASN)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func loadDB(dbType string) (reader *geoip2.Reader, err error) {
+	oldDB := GetDB(dbType)
+	if oldDB != nil {
+		oldDB.Close()
+	}
+
+	dbReader, err := geoip2.Open(GetDBFilePath(dbType))
+	if err != nil {
+		log.Fatalf("Error opening DB file %s, %s", dbType, err)
+		return nil, err
+	}
+
+	return dbReader, nil
+}
+
+func GetDB(dbType string) *geoip2.Reader {
+	dbLock.Lock()
+	defer dbLock.Unlock()
+
+	switch dbType {
+	case constants.DBTypeCountry:
+		return dbCountryReader
+	case constants.DBTypeCity:
+		return dbCityReader
+	case constants.DBTypeASN:
+		return dbAsnReader
+	default:
+		return nil
+	}
+}

--- a/internal/maxmind/database_test.go
+++ b/internal/maxmind/database_test.go
@@ -1,0 +1,69 @@
+package maxmind
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hibare/GoGeoIP/internal/constants"
+	"github.com/hibare/GoGeoIP/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadAllDB(t *testing.T) {
+	err := testhelper.LoadTestDB()
+	assert.NoError(t, err)
+
+	t.Cleanup(func() {
+		os.RemoveAll(constants.AssetDir)
+	})
+
+	err = LoadAllDB()
+	assert.NoError(t, err)
+
+	assert.NotNil(t, dbCountryReader)
+	assert.NotNil(t, dbCityReader)
+	assert.NotNil(t, dbAsnReader)
+}
+
+func TestLoadDB(t *testing.T) {
+	err := testhelper.LoadTestDB()
+	assert.NoError(t, err)
+
+	t.Cleanup(func() {
+		os.RemoveAll(constants.AssetDir)
+	})
+
+	countryDB, err := loadDB(constants.DBTypeCountry)
+	assert.NoError(t, err)
+	assert.NotNil(t, countryDB)
+
+	cityDB, err := loadDB(constants.DBTypeCity)
+	assert.NoError(t, err)
+	assert.NotNil(t, cityDB)
+
+	asnDB, err := loadDB(constants.DBTypeASN)
+	assert.NoError(t, err)
+	assert.NotNil(t, asnDB)
+}
+
+func TestGetDB(t *testing.T) {
+	err := testhelper.LoadTestDB()
+	assert.NoError(t, err)
+
+	t.Cleanup(func() {
+		os.RemoveAll(constants.AssetDir)
+	})
+
+	dbCountryReader = nil
+	dbCityReader = nil
+	dbAsnReader = nil
+
+	countryDB := GetDB(constants.DBTypeCountry)
+	assert.NotNil(t, countryDB)
+
+	cityDB := GetDB(constants.DBTypeCity)
+	assert.NotNil(t, cityDB)
+
+	asnDB := GetDB(constants.DBTypeASN)
+	assert.NotNil(t, asnDB)
+}

--- a/internal/maxmind/database_test.go
+++ b/internal/maxmind/database_test.go
@@ -54,10 +54,6 @@ func TestGetDB(t *testing.T) {
 		os.RemoveAll(constants.AssetDir)
 	})
 
-	dbCountryReader = nil
-	dbCityReader = nil
-	dbAsnReader = nil
-
 	countryDB := GetDB(constants.DBTypeCountry)
 	assert.NotNil(t, countryDB)
 

--- a/internal/maxmind/download.go
+++ b/internal/maxmind/download.go
@@ -130,6 +130,8 @@ func DownloadAllDB() {
 			log.Fatalf("Error downloading DB: %v", err)
 		}
 	}
+
+	LoadAllDB()
 }
 
 func RunDBDownloadJob() {

--- a/internal/maxmind/maxmind.go
+++ b/internal/maxmind/maxmind.go
@@ -4,7 +4,6 @@ import (
 	"net"
 
 	"github.com/hibare/GoGeoIP/internal/constants"
-	"github.com/oschwald/geoip2-golang"
 )
 
 type IPCountry struct {
@@ -47,13 +46,7 @@ func IP2Country(ip string) (IPCountry, error) {
 		return ipCountry, constants.ErrInvalidIP
 	}
 
-	db, err := geoip2.Open(GetDBFilePath(constants.DBTypeCountry))
-	if err != nil {
-		return ipCountry, err
-	}
-	defer db.Close()
-
-	record, err := db.Country(parsedIP)
+	record, err := GetDB(constants.DBTypeCountry).Country(parsedIP)
 	if err != nil {
 		return ipCountry, err
 	}
@@ -77,13 +70,7 @@ func IP2City(ip string) (IPCity, error) {
 		return ipCity, constants.ErrInvalidIP
 	}
 
-	db, err := geoip2.Open(GetDBFilePath(constants.DBTypeCity))
-	if err != nil {
-		return ipCity, err
-	}
-	defer db.Close()
-
-	record, err := db.City(parsedIP)
+	record, err := GetDB(constants.DBTypeCity).City(parsedIP)
 	if err != nil {
 		return ipCity, err
 	}
@@ -111,13 +98,7 @@ func IP2ASN(ip string) (IPASN, error) {
 		return ipAsn, constants.ErrInvalidIP
 	}
 
-	db, err := geoip2.Open(GetDBFilePath(constants.DBTypeASN))
-	if err != nil {
-		return ipAsn, err
-	}
-	defer db.Close()
-
-	record, err := db.ASN(parsedIP)
+	record, err := GetDB(constants.DBTypeASN).ASN(parsedIP)
 	if err != nil {
 		return ipAsn, err
 	}

--- a/internal/testhelper/testhelper.go
+++ b/internal/testhelper/testhelper.go
@@ -59,5 +59,6 @@ func LoadTestDB() error {
 			return err
 		}
 	}
+
 	return nil
 }


### PR DESCRIPTION
This PR optimizes performance by introducing an in-memory cache for the GeoIP databases. Now, cached data is reused for every request, eliminating the need to reload databases from disk. This substantially reduces the overall request processing time.