### PR TITLE
Fix typo in JSON response

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ docker compose up
   "latitude": 37.751,
   "longitude": -97.822,
   "asn": 15169,
-  "oraganization": "GOOGLE",
+  "organization": "GOOGLE",
   "ip": "8.8.8.8"
 }
 ```

--- a/internal/maxmind/maxmind.go
+++ b/internal/maxmind/maxmind.go
@@ -28,7 +28,7 @@ type IPCity struct {
 type IPASN struct {
 	IP           string `json:"ip"`
 	ASN          uint   `json:"asn"`
-	Organization string `json:"oraganization"`
+	Organization string `json:"organization"`
 }
 
 type GeoIP struct {


### PR DESCRIPTION
This PR fixes a typo in the word organization returned by the API.