### PR TITLE
chore: fix pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
       - id: go-test-mod
 
   - repo: https://github.com/sqlfluff/sqlfluff
-    rev: 4.0.0a2
+    rev: 4.2.1
     hooks:
       - id: sqlfluff-lint
         args: [--dialect, postgres, --exclude-rules, "RF06,RF04"]


### PR DESCRIPTION
Update pre-commit hooks: upgrade stale versions, pin sqlfluff to stable, upgrade black, remove stale hooks, and fix missing hooks.