### PR TITLE
chore: add pre-commit ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,3 +69,20 @@ updates:
       npm:
         patterns:
           - "*"
+
+  # Maintain dependencies for pre-commit
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "friday"
+      time: "00:30"
+    target-branch: "main"
+    cooldown:
+      default-days: 10
+    assignees:
+      - "hibare"
+    groups:
+      pre-commit:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds Dependabot configuration for pre-commit hooks.

Pre-commit hooks will now be automatically checked for updates on a monthly schedule.