### PR TITLE
fix: extract real client IP from proxy headers instead of RemoteAddr

### DIFF
--- a/cmd/server/handlers/geoip.go
+++ b/cmd/server/handlers/geoip.go
@@ -3,7 +3,9 @@ package handlers
 import (
 	"errors"
 	"log/slog"
+	"net"
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	commonErrors "github.com/hibare/GoCommon/v2/pkg/errors"
@@ -43,9 +45,36 @@ func (h *GeoIP) GetGeoIP(w http.ResponseWriter, r *http.Request) {
 	commonHttp.WriteJSONResponse(w, http.StatusOK, ipGeo)
 }
 
+// clientIP extracts the real client IP from request headers.
+// Checks Cloudflare Cf-Connecting-Ip first, then X-Forwarded-For, then falls back to RemoteAddr.
+func clientIP(r *http.Request) string {
+	// Cloudflare sends the real client IP in this header.
+	if ip := r.Header.Get("Cf-Connecting-Ip"); ip != "" {
+		if strings.Contains(ip, ",") {
+			ip = strings.TrimSpace(strings.Split(ip, ",")[0])
+		}
+		return ip
+	}
+
+	// Standard reverse proxy header.
+	if ip := r.Header.Get("X-Forwarded-For"); ip != "" {
+		if strings.Contains(ip, ",") {
+			ip = strings.TrimSpace(strings.Split(ip, ",")[0])
+		}
+		return ip
+	}
+
+	// Fall back to the TCP source address, stripping the port.
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
 // GetMyIP handles requests to get GeoIP information for the requester's IP.
 func (h *GeoIP) GetMyIP(w http.ResponseWriter, r *http.Request) {
-	ipStr := r.RemoteAddr
+	ipStr := clientIP(r)
 
 	if h.cfg.Core.Environment == config.EnvironmentDevelopment || h.cfg.Core.Environment == config.EnvironmentTesting {
 		ipStr = "8.8.8.8"

--- a/cmd/server/handlers/geoip.go
+++ b/cmd/server/handlers/geoip.go
@@ -50,18 +50,18 @@ func (h *GeoIP) GetGeoIP(w http.ResponseWriter, r *http.Request) {
 func clientIP(r *http.Request) string {
 	// Cloudflare sends the real client IP in this header.
 	if ip := r.Header.Get("Cf-Connecting-Ip"); ip != "" {
-		if strings.Contains(ip, ",") {
-			ip = strings.TrimSpace(strings.Split(ip, ",")[0])
+		if i := strings.Index(ip, ","); i != -1 {
+			ip = ip[:i]
 		}
-		return ip
+		return strings.TrimSpace(ip)
 	}
 
 	// Standard reverse proxy header.
 	if ip := r.Header.Get("X-Forwarded-For"); ip != "" {
-		if strings.Contains(ip, ",") {
-			ip = strings.TrimSpace(strings.Split(ip, ",")[0])
+		if i := strings.Index(ip, ","); i != -1 {
+			ip = ip[:i]
 		}
-		return ip
+		return strings.TrimSpace(ip)
 	}
 
 	// Fall back to the TCP source address, stripping the port.

--- a/cmd/server/handlers/geoip_test.go
+++ b/cmd/server/handlers/geoip_test.go
@@ -1,0 +1,61 @@
+package handlers
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClientIP_CloudflareHeader(t *testing.T) {
+	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Cf-Connecting-Ip", "203.0.113.1")
+	r.RemoteAddr = "10.42.2.50:57056"
+
+	assert.Equal(t, "203.0.113.1", clientIP(r))
+}
+
+func TestClientIP_XForwardedFor(t *testing.T) {
+	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-Forwarded-For", "198.51.100.2")
+	r.RemoteAddr = "10.42.2.50:57056"
+
+	assert.Equal(t, "198.51.100.2", clientIP(r))
+}
+
+func TestClientIP_PrefersCloudflareOverXForwardedFor(t *testing.T) {
+	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Cf-Connecting-Ip", "203.0.113.1")
+	r.Header.Set("X-Forwarded-For", "198.51.100.2")
+	r.RemoteAddr = "10.42.2.50:57056"
+
+	assert.Equal(t, "203.0.113.1", clientIP(r))
+}
+
+func TestClientIP_FallsBackToRemoteAddr(t *testing.T) {
+	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "203.0.113.1:8080"
+
+	assert.Equal(t, "203.0.113.1", clientIP(r))
+}
+
+func TestClientIP_RemoteAddrNoPort(t *testing.T) {
+	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "203.0.113.1"
+
+	assert.Equal(t, "203.0.113.1", clientIP(r))
+}
+
+func TestClientIP_XForwardedForMultiple(t *testing.T) {
+	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-Forwarded-For", "203.0.113.1, 198.51.100.2, 10.0.0.1")
+	r.RemoteAddr = "10.42.2.50:57056"
+
+	assert.Equal(t, "203.0.113.1", clientIP(r))
+}
+
+func TestClientIP_NoHeaders(t *testing.T) {
+	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+
+	assert.Equal(t, "", clientIP(r))
+}

--- a/cmd/server/handlers/geoip_test.go
+++ b/cmd/server/handlers/geoip_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -8,7 +9,7 @@ import (
 )
 
 func TestClientIP_CloudflareHeader(t *testing.T) {
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+	r, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
 	r.Header.Set("Cf-Connecting-Ip", "203.0.113.1")
 	r.RemoteAddr = "10.42.2.50:57056"
 
@@ -16,7 +17,7 @@ func TestClientIP_CloudflareHeader(t *testing.T) {
 }
 
 func TestClientIP_XForwardedFor(t *testing.T) {
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+	r, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
 	r.Header.Set("X-Forwarded-For", "198.51.100.2")
 	r.RemoteAddr = "10.42.2.50:57056"
 
@@ -24,7 +25,7 @@ func TestClientIP_XForwardedFor(t *testing.T) {
 }
 
 func TestClientIP_PrefersCloudflareOverXForwardedFor(t *testing.T) {
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+	r, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
 	r.Header.Set("Cf-Connecting-Ip", "203.0.113.1")
 	r.Header.Set("X-Forwarded-For", "198.51.100.2")
 	r.RemoteAddr = "10.42.2.50:57056"
@@ -33,21 +34,21 @@ func TestClientIP_PrefersCloudflareOverXForwardedFor(t *testing.T) {
 }
 
 func TestClientIP_FallsBackToRemoteAddr(t *testing.T) {
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+	r, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
 	r.RemoteAddr = "203.0.113.1:8080"
 
 	assert.Equal(t, "203.0.113.1", clientIP(r))
 }
 
 func TestClientIP_RemoteAddrNoPort(t *testing.T) {
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+	r, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
 	r.RemoteAddr = "203.0.113.1"
 
 	assert.Equal(t, "203.0.113.1", clientIP(r))
 }
 
 func TestClientIP_XForwardedForMultiple(t *testing.T) {
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+	r, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
 	r.Header.Set("X-Forwarded-For", "203.0.113.1, 198.51.100.2, 10.0.0.1")
 	r.RemoteAddr = "10.42.2.50:57056"
 
@@ -55,7 +56,7 @@ func TestClientIP_XForwardedForMultiple(t *testing.T) {
 }
 
 func TestClientIP_NoHeaders(t *testing.T) {
-	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+	r, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
 
-	assert.Equal(t, "", clientIP(r))
+	assert.Empty(t, clientIP(r))
 }


### PR DESCRIPTION
The GeoIP handler was using r.RemoteAddr to get the client IP, which returns the internal Kubernetes pod IP when behind a reverse proxy (Traefik/Cloudflare). This caused GeoIP lookups to fail with 'invalid IP address' errors when serving real clients behind Cloudflare.

Added a clientIP helper that checks:
1. Cf-Connecting-Ip (Cloudflare)
2. X-Forwarded-For (standard proxy header)
3. Falls back to RemoteAddr with port stripped

Removed middleware.RealIP from the chi middleware chain since the handler now handles IP extraction directly.

Tests added using testify covering all the header/RemoteAddr paths.